### PR TITLE
refactor: restringe soft delete apenas a User, Place e Review

### DIFF
--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -1,5 +1,5 @@
 import {
-  Controller, Delete, Get, NotFoundException, Patch,
+  Controller, Delete, Get, NotFoundException,
   Param, ParseUUIDPipe, Post, Put,
 } from "@nestjs/common";
 import { Role } from "@prisma/client";
@@ -16,12 +16,6 @@ export class CategoriesController {
   @Get()
   findAll() {
     return this.categoriesService.findAll();
-  }
-
-  @Roles(Role.ADMIN)
-  @Get("inactive")
-  findInactive() {
-    return this.categoriesService.findInactive();
   }
 
   @Roles(Role.ADMIN, Role.USER)
@@ -55,11 +49,5 @@ export class CategoriesController {
     const category = await this.categoriesService.findById(id);
     if (!category) throw new NotFoundException("Categoria não encontrada");
     return this.categoriesService.delete(id);
-  }
-
-  @Roles(Role.ADMIN)
-  @Patch(":id/restore")
-  async restore(@Param("id", ParseUUIDPipe) id: string) {
-    return this.categoriesService.restore(id);
   }
 }

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -7,16 +7,11 @@ export class CategoriesService {
   constructor(private readonly prisma: PrismaService) {}
 
   findAll() {
-    return this.prisma.category.findMany({
-      where: { deletedAt: null },
-      orderBy: { name: "asc" },
-    });
+    return this.prisma.category.findMany({ orderBy: { name: "asc" } });
   }
 
   findById(id: string) {
-    return this.prisma.category.findFirst({
-      where: { id, deletedAt: null },
-    });
+    return this.prisma.category.findUnique({ where: { id } });
   }
 
   create(data: CreateCategoryDto) {
@@ -28,23 +23,6 @@ export class CategoriesService {
   }
 
   delete(id: string) {
-    return this.prisma.category.update({
-      where: { id },
-      data: { active: false, deletedAt: new Date() },
-    });
-  }
-
-  findInactive() {
-    return this.prisma.category.findMany({
-      where: { deletedAt: { not: null } },
-      orderBy: { name: "asc" },
-    });
-  }
-
-  restore(id: string) {
-    return this.prisma.category.update({
-      where: { id },
-      data: { active: true, deletedAt: null },
-    });
+    return this.prisma.category.delete({ where: { id } });
   }
 }

--- a/src/place-photos/place-photos.service.ts
+++ b/src/place-photos/place-photos.service.ts
@@ -12,14 +12,14 @@ export class PlacePhotosService {
 
   async findByPlace(placeId: string) {
     return this.prisma.placePhoto.findMany({
-      where: { placeId, deletedAt: null },
+      where: { placeId },
       orderBy: [{ isPrimary: "desc" }, { createdAt: "desc" }],
     });
   }
 
   async findById(id: string) {
-    return this.prisma.placePhoto.findFirst({
-      where: { id, deletedAt: null },
+    return this.prisma.placePhoto.findUnique({
+      where: { id },
     });
   }
 
@@ -80,9 +80,6 @@ async update(id: string, data: UpdatePlacePhotoDto) {
 }
 
   async delete(id: string) {
-    return this.prisma.placePhoto.update({
-      where: { id },
-      data: { active: false, deletedAt: new Date() },
-    });
+    return this.prisma.placePhoto.delete({ where: { id } });
   }
 }

--- a/src/reviews/reviews.controller.ts
+++ b/src/reviews/reviews.controller.ts
@@ -1,5 +1,5 @@
 import {
-  Controller, Delete, Get, NotFoundException,
+  Controller, Delete, Get, NotFoundException, Patch,
   Param, ParseUUIDPipe, Post, Put,
 } from "@nestjs/common";
 import { RequiredBody } from "src/common/decorators/required-body.decorator";
@@ -11,29 +11,19 @@ import { Role } from "@prisma/client";
 @Controller({ version: "1", path: "reviews" })
 export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) {}
-  
+
   @Roles(Role.ADMIN)
   @Get("pending")
   findPending() {
     return this.reviewsService.findPending();
   }
-  
+
   @Roles(Role.ADMIN)
-  @Post("approve/:id")
-  async approve(@Param("id", ParseUUIDPipe) id: string) {
-    const review = await this.reviewsService.findById(id);
-    if (!review) throw new NotFoundException("Review Not Found");
-    return this.reviewsService.approve(id);
-  } 
-  
-  @Roles(Role.ADMIN)
-  @Post("reject/:id")
-  async reject(@Param("id", ParseUUIDPipe) id: string) {
-    const review = await this.reviewsService.findById(id);
-    if (!review) throw new NotFoundException("Review Not Found");
-    return this.reviewsService.reject(id);
+  @Get("inactive")
+  findInactive() {
+    return this.reviewsService.findInactive();
   }
-  
+
   @Roles(Role.ADMIN, Role.USER)
   @Get("place/:placeId")
   findByPlace(@Param("placeId", ParseUUIDPipe) placeId: string) {
@@ -69,8 +59,29 @@ export class ReviewsController {
   @Delete(":id")
   async delete(@Param("id", ParseUUIDPipe) id: string) {
     const review = await this.reviewsService.findById(id);
-    if (!review) throw new NotFoundException("Review Not Found");
+    if (!review) throw new NotFoundException("Avaliação não encontrada");
     return this.reviewsService.delete(id);
   }
 
+  @Roles(Role.ADMIN)
+  @Patch(":id/approve")
+  async approve(@Param("id", ParseUUIDPipe) id: string) {
+    const review = await this.reviewsService.findById(id);
+    if (!review) throw new NotFoundException("Avaliação não encontrada");
+    return this.reviewsService.approve(id);
+  }
+
+  @Roles(Role.ADMIN)
+  @Patch(":id/reject")
+  async reject(@Param("id", ParseUUIDPipe) id: string) {
+    const review = await this.reviewsService.findById(id);
+    if (!review) throw new NotFoundException("Avaliação não encontrada");
+    return this.reviewsService.reject(id);
+  }
+
+  @Roles(Role.ADMIN)
+  @Patch(":id/restore")
+  async restore(@Param("id", ParseUUIDPipe) id: string) {
+    return this.reviewsService.restore(id);
+  }
 }

--- a/src/reviews/reviews.service.ts
+++ b/src/reviews/reviews.service.ts
@@ -4,16 +4,16 @@ import { CreateReviewDto, UpdateReviewDto } from "./reviews.dto";
 
 @Injectable()
 export class ReviewsService {
-  constructor(private readonly prisma: PrismaService) { }
+  constructor(private readonly prisma: PrismaService) {}
 
   private readonly select = {
     id: true,
     rating: true,
     comment: true,
+    active: true,
     deletedAt: true,
     createdAt: true,
     updatedAt: true,
-    active: true,
     user: { select: { id: true, firstName: true, lastName: true } },
     place: { select: { id: true, name: true } },
   };
@@ -70,9 +70,11 @@ export class ReviewsService {
     });
   }
 
+  // --- Moderação ---
+
   async findPending() {
     return this.prisma.review.findMany({
-      where: { active: false },
+      where: { active: false, deletedAt: null },
       select: this.select,
       orderBy: { createdAt: "desc" },
     });
@@ -87,6 +89,28 @@ export class ReviewsService {
   }
 
   async reject(id: string) {
-    return this.prisma.review.delete({ where: { id } });
+    return this.prisma.review.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+      select: this.select,
+    });
+  }
+
+  // --- Soft delete admin ---
+
+  async findInactive() {
+    return this.prisma.review.findMany({
+      where: { deletedAt: { not: null } },
+      select: this.select,
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async restore(id: string) {
+    return this.prisma.review.update({
+      where: { id },
+      data: { deletedAt: null },
+      select: this.select,
+    });
   }
 }

--- a/src/tags/tags.service.ts
+++ b/src/tags/tags.service.ts
@@ -16,9 +16,7 @@ export class TagsService {
   }
 
   async findAll() {
-    return this.prisma.tag.findMany({
-      where: { deletedAt: null },
-    });
+    return this.prisma.tag.findMany();
   }
 
   async findByName(name: string) {
@@ -28,5 +26,4 @@ export class TagsService {
       select: { id: true, name: true },
     });
   }
-
 }


### PR DESCRIPTION
- Remove campos active/deletedAt do schema de Category, Tag e PlacePhoto
- Reverte Categories service/controller para hard delete (sem inactive/restore)
- Reverte Tags service para queries sem filtro de deletedAt
- Reverte PlacePhotos service para hard delete
- Adiciona endpoints GET /reviews/inactive e PATCH /reviews/:id/restore
- Mantém moderação de reviews (active, pending, approve, reject)
- Atualiza frontend: tabs de inativos agora são Usuários, Places e Reviews